### PR TITLE
[FEATURE] Support navigation title for sys_site_language

### DIFF
--- a/Configuration/SiteConfigurationTCA/sys_site_language.php
+++ b/Configuration/SiteConfigurationTCA/sys_site_language.php
@@ -41,6 +41,15 @@ return [
                 'placeholder' => 'English',
             ]
         ],
+        'nav_title' => [
+            'label' => 'Language navigation title (localized e.g. "English", "Deutsch", "Français")',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'trim',
+                'placeholder' => 'English',
+            ]
+        ],
         'base' => [
             'label' => 'Entry point (either https://www.mydomain.fr/ or /fr/)',
             'config' => [
@@ -53,7 +62,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'eval' => 'required',
-                'placeholder' => 'fr_FR.UTF-8',
+                'placeholder' => 'en_US.UTF-8',
             ]
         ],
         'iso-639-1' => [
@@ -63,6 +72,30 @@ return [
                 'renderType' => 'selectSingle',
                 // Fed by data provider
                 'items' => [],
+                'itemsProcFunc' => \TYPO3\CMS\Core\Service\IsoCodeService::class . '->renderIsoCodeSelectDropdown',
+            ],
+        ],
+        'hrefLanguage' => [
+            'label' => 'Language locale',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'required',
+                'placeholder' => 'en-US',
+            ]
+        ],
+        'direction' => [
+            'label' => 'Direction',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 'None', ''],
+                    ['ltr', 'Left to right', ''],
+                    ['rtl', 'Right to left', '']
+                ],
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
             ],
         ],
         'typo3Language' => [
@@ -372,7 +405,7 @@ return [
     ],
     'types' => [
         '1' => [
-            'showitem' => 'languageId, title, base, locale, iso-639-1, typo3Language, flag, fallbackType, fallbacks',
+            'showitem' => 'languageId, title, nav_title, base, locale, iso-639-1, hrefLanguage, direction, typo3Language, flag, fallbackType, fallbacks',
         ],
     ],
 ];

--- a/Configuration/SiteConfigurationTCA/sys_site_language.php
+++ b/Configuration/SiteConfigurationTCA/sys_site_language.php
@@ -41,6 +41,15 @@ return [
                 'placeholder' => 'English',
             ]
         ],
+        'nav_title' => [
+            'label' => 'Language navigation title (localized e.g. "English", "Deutsch", "Français")',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'trim',
+                'placeholder' => 'English',
+            ]
+        ],
         'base' => [
             'label' => 'Entry point (either https://www.mydomain.fr/ or /fr/)',
             'config' => [
@@ -372,7 +381,7 @@ return [
     ],
     'types' => [
         '1' => [
-            'showitem' => 'languageId, title, base, locale, iso-639-1, typo3Language, flag, fallbackType, fallbacks',
+            'showitem' => 'languageId, title, nav_title, base, locale, iso-639-1, typo3Language, flag, fallbackType, fallbacks',
         ],
     ],
 ];


### PR DESCRIPTION
The new field nav_title in sys_site_language makes it possible to create localized language menus e.g. used by bootstrap_package.

After a short discussion on Slack today with @wmdbMattes and @benjaminkott we thought it could be helpful to have a new field for the navigation title like available in pages.